### PR TITLE
Add base CircleCI configuration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,28 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker login -e . -p ${QUAY_PASSWORD} -u ${QUAY_USER} quay.io
+
+test:
+  pre:
+    - docker build -t quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:${CIRCLE_SHA1:0:7} .
+  override:
+    - /bin/true
+
+deployment:
+  latest:
+    branch: develop
+    commands:
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:${CIRCLE_SHA1:0:7}
+      - docker tag -f quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:${CIRCLE_SHA1:0:7} quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:latest
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:latest
+
+  release:
+    tag: /[0-9]+(\.[0-9]+)*/
+    commands:
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:$(git tag -l --contains HEAD)
+      - docker tag -f quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:$(git tag -l --contains HEAD) quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:latest
+      - docker push quay.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME:7}:latest


### PR DESCRIPTION
Currently, CircleCI isn't actually running any tests (only `/bin/true`), but that can easily be updated in `circle.yml`.

More interesting is that CircleCI is setup to build and publish container images (to Quay) for all merges into `develop` using the first seven characters of the Git commit as the container image's tag. Git tag pushes also produce container images, which are identified by the same version number of the tag.

See also:
- https://quay.io/repository/azavea/django
- https://circleci.com/gh/azavea/docker-django
