### PR TITLE
Add base Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+sudo: required
+
+language: bash
+
+services:
+  - docker
+
+install:
+  - docker build -t quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${TRAVIS_COMMIT:0:7} .
+
+script:
+  - "/bin/true"
+
+before_deploy:
+  - docker login -e . -p "${QUAY_PASSWORD}" -u "${QUAY_USER}" quay.io
+
+deploy:
+  - provider: script
+    script: ".travis/deploy.sh"
+    on:
+      repo: azavea/docker-django
+      branch: develop
+  - provider: script
+    script: ".travis/deploy.sh"
+    on:
+      repo: azavea/docker-django
+      tags: true
+
+notifications:
+  slack:
+    secure: J6dNkUZa+UL0B8y5nhC6NnN8KjCJNQ7RmEH/rJwYlcW5QEcUXHSYMbRfWY1vw5YnEALqKRGipx0kZmJ07BKQ9djKdkT0AoeuGXf0z9s1ZGtScCBV5V9oWI8C9jQ120CJa8EBBW1jDgtfKI97N8MUjPrKRpF88Gf/1pmO0MFLMCv8zSqZ346ZEpiv1bU900cFsfQwjaST8p8gdL6Q9KEt+rKCulvuQCavBIyamrkTjgmvTK6T4dy/1wXAgWIu5dk0tRJYOwarPc70YKcGLovJ9VR6caJ+UoIV07tywf71TSixJBVIPoFupBzVtFd+jE6XAHrQZrGrpmbt0saicjOQelFM8QcXBQYVBbKBgBz8P5M5SsqqKEHfgSnrg8tSAlhqJmwujwlGNukiLCsWnG8eUnDageRoFShjWaPtdZjdpP0Sj0x/VUX/jf+pNiypFZRSqMxsFFvHjqElc25eZkhLBCmka6f3ASd3ikEb4Sh4gsBm6YLzbM1FFJlfs23A3qsPp9KbBXMyniTnHqPD7hNIk58aW7k3uRNTCJUsd754wWX27lTpV3rmnZbsK+xxIFozJlWA3jG9R9E0BUUjrsxym1jUrrm0Y1YZ0NF+jIpbhreapd8gmwp6/OqWAFR8n5hjJCIcA43G5Czy76BvAGg857r08UC8XWcKNZcrQsuIBjM=

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "${TRAVIS_TAG}" ]; then
+  QUAY_TAG="${TRAVIS_COMMIT:0:7}"
+else
+  QUAY_TAG="${TRAVIS_TAG}"
+
+  docker tag -f "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${TRAVIS_COMMIT:0:7}" "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${QUAY_TAG}"
+fi
+
+docker push "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${QUAY_TAG}"
+docker tag -f "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:${QUAY_TAG}" "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:latest"
+docker push "quay.io/${TRAVIS_REPO_SLUG:0:6}/${TRAVIS_REPO_SLUG:14}:latest"


### PR DESCRIPTION
Currently, Travis CI isn't actually running any tests (only `/bin/true`), but that can easily be updated in `.travis.yml`.

More interesting is that Travis CI is setup to build and publish container images (to Quay) for all merges into `develop` using the first seven characters of the Git commit as the container image's tag. Git tag pushes also produce container images, which are identified by the same version number of the tag.

See also:
- https://quay.io/repository/azavea/django
- https://travis-ci.org/azavea/docker-django
