### PR TITLE
Bump Django version to 1.9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ Then, run the container:
 
 ```bash
 $ docker run --rm --entrypoint pip quay.io/azavea/django:latest freeze
-Django==1.9.2
+Django==1.9.5
 gevent==1.0.2
 greenlet==0.4.9
 gunicorn==19.4.5
 psycopg2==2.6.1
-wheel==0.26.0
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.4.5
-django==1.9.2
+django==1.9.5
 psycopg2==2.6.1
 gevent==1.0.2


### PR DESCRIPTION
See also:
- https://docs.djangoproject.com/en/1.9/releases/1.9.3/
- https://docs.djangoproject.com/en/1.9/releases/1.9.4/
- https://docs.djangoproject.com/en/1.9/releases/1.9.5/
