### PR TITLE
Bump Django to 1.9.7; separate build and runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,23 @@ FROM python:2.7-slim
 
 MAINTAINER Azavea <systems@azavea.com>
 
-# Install dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+COPY requirements.txt /tmp/
+
+RUN set -ex \
+  && buildDeps=' \
     build-essential \
-    gdal-bin \
     libpq-dev \
     python-dev \
+	' \
+  && deps=' \
+    gdal-bin \
     git \
-    postgresql-client-9.4 && \
-    rm -rf /var/lib/apt/lists/*
-
-COPY requirements.txt /tmp/
-RUN pip install --no-cache-dir -r /tmp/requirements.txt \
-  && rm /tmp/requirements.txt
+    postgresql-client-9.4 \
+  ' \
+  && apt-get update && apt-get install -y ${buildDeps} ${deps} --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install --no-cache-dir -r /tmp/requirements.txt \
+  && rm /tmp/requirements.txt \
+  && apt-get purge -y --auto-remove ${buildDeps}
 
 ENTRYPOINT ["gunicorn"]

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Then, run the container:
 
 ```bash
 $ docker run --rm --entrypoint pip quay.io/azavea/django:latest freeze
-Django==1.9.6
+Django==1.9.7
 gevent==1.1.1
 greenlet==0.4.9
-gunicorn==19.4.5
+gunicorn==19.6.0
 psycopg2==2.6.1
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gunicorn==19.4.5
-django==1.9.6
+gunicorn==19.6.0
+django==1.9.7
 psycopg2==2.6.1
 gevent==1.1.1


### PR DESCRIPTION
Separate build dependencies from runtime dependencies. Ensure that build dependencies are removed before the container image is finalized.

See also: https://docs.djangoproject.com/en/1.9/releases/1.9.7/
