### PR TITLE
Update Django to 1.9.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Azavea <systems@azavea.com>
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 
 ENV PG_MAJOR 9.5
-ENV PG_CLIENT_VERSION 9.5+175.pgdg80+1
+ENV PG_CLIENT_VERSION 9.6+177.pgdg80+1
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' ${PG_MAJOR} > /etc/apt/sources.list.d/pgdg.list
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Then, run the container:
 
 ```bash
 $ docker run --rm --entrypoint pip quay.io/azavea/django:latest freeze
-Django==1.9.9
-gevent==1.1.1
+Django==1.9.10
+gevent==1.1.2
 greenlet==0.4.10
 gunicorn==19.6.0
 psycopg2==2.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.6.0
-django==1.9.9
+django==1.9.10
 psycopg2==2.6.2
-gevent==1.1.1
+gevent==1.1.2


### PR DESCRIPTION
Also, bump Gevent to 1.1.2.

See:
- https://docs.djangoproject.com/en/1.10/releases/1.9.10/
- http://www.gevent.org/changelog.html#jul-21-2016

---

**Testing**

Ensure that following the steps outlined in the `README` match their stated output.
