### PR TITLE
Update Django to 1.9.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Then, run the container:
 
 ```bash
 $ docker run --rm --entrypoint pip quay.io/azavea/django:latest freeze
-Django==1.9.10
+Django==1.9.11
 gevent==1.1.2
 greenlet==0.4.10
 gunicorn==19.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.6.0
-django==1.9.10
+django==1.9.11
 psycopg2==2.6.2
 gevent==1.1.2


### PR DESCRIPTION
Django 1.10.3, 1.9.11, and 1.8.16 will be released on Nov 1 2016 around 1400 UTC. They will fix several security defects with maximum severity "moderate".
