### PR TITLE
Update to Django 1.10.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.6.0
-django==1.9.11
+django==1.10.3
 psycopg2==2.6.2
 gevent==1.1.2


### PR DESCRIPTION
Updates to Django 1.10.3 to support newer Django projects as 1.9 is past the end of its "mainstream support" date.

Output of `pip freeze`:
```
andrew@hatteras:~/src/docker-django$ docker run --rm --entrypoint pip django:1.10.3 freeze                                                       
You are using pip version 8.1.2, however version 9.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Django==1.10.3
gevent==1.1.2
greenlet==0.4.10
gunicorn==19.6.0
psycopg2==2.6.2
```

Can cut a release and merge to master once PR accepted.