### PR TITLE
Bump Django 1.10.x to 1.10.6

### DIFF
--- a/1.10/requirements.txt
+++ b/1.10/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.6.0
-django==1.10.5
+django==1.10.6
 psycopg2==2.6.2
 gevent==1.2.1


### PR DESCRIPTION
See: https://docs.djangoproject.com/en/1.10/releases/1.10.6/

---

**Testing**

Ensure that all of the matrix builds [here](https://travis-ci.org/azavea/docker-django/builds/206627105) pass.