### PR TITLE
Upgrade to Django 1.10.x and 1.9.x security releases

### DIFF
--- a/1.10/requirements.txt
+++ b/1.10/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.6.0
-django==1.10.6
-psycopg2==2.6.2
+django==1.10.7
+psycopg2==2.7.1
 gevent==1.2.1

--- a/1.9/requirements.txt
+++ b/1.9/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.6.0
-django==1.9.12
-psycopg2==2.6.2
+django==1.9.13
+psycopg2==2.7.1
 gevent==1.2.1


### PR DESCRIPTION
In addition, upgrade Pyscopg2 to 2.7.x from 2.6.x.

These changes are expected to fail until the releases occur on ~4/4.

---

**Testing**

Inspect the Travis CI build output for this pull request to ensure that all builds pass.