### PR TITLE
Bump Django versions to 1.11.10 and 2.0.2

### DIFF
--- a/1.11/requirements.txt
+++ b/1.11/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.7.1
-django==1.11.9
+django==1.11.10
 psycopg2==2.7.3.2
 gevent==1.2.2

--- a/2.0/requirements.txt
+++ b/2.0/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.7.1
-django==2.0.1
+django==2.0.2
 psycopg2==2.7.3.2
 gevent==1.2.2


### PR DESCRIPTION
Update Django 1.11.x and 2.0.x.

See:

- https://docs.djangoproject.com/en/2.0/releases/2.0.2/
- https://docs.djangoproject.com/en/1.11/releases/1.11.10/

Fixes #41 

---

**Testing**

See Travis CI build: https://travis-ci.org/azavea/docker-django/builds/333870142