### PR TITLE
Cease installing Psycopg2 binary package

### DIFF
--- a/1.10/requirements.txt
+++ b/1.10/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.7.1
 django==1.10.8
-psycopg2==2.7.4
+psycopg2==2.7.4 --no-binary psycopg2
 gevent==1.2.2

--- a/1.11/requirements.txt
+++ b/1.11/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.7.1
 django==1.11.11
-psycopg2==2.7.4
+psycopg2==2.7.4 --no-binary psycopg2
 gevent==1.2.2

--- a/1.9/requirements.txt
+++ b/1.9/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.7.1
 django==1.9.13
-psycopg2==2.7.4
+psycopg2==2.7.4 --no-binary psycopg2
 gevent==1.2.2

--- a/2.0/requirements.txt
+++ b/2.0/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.7.1
 django==2.0.3
-psycopg2==2.7.3.2
+psycopg2==2.7.4 --no-binary psycopg2
 gevent==1.2.2


### PR DESCRIPTION
This suppresses warnings emitted by version 2.7.x when the package was installed as a wheel. This change also ensures that we use the system version of OpenSSL and libpq.

When version 2.8.x comes around, all we need to do is update the version numbers of the `psycopg2` package and keep the additional flags as is. Using the source build is desired in that it gives us a bit more control over the versions of OpenSSL and libpq used.

Fixes https://github.com/azavea/docker-django/issues/45

---

**Testing**

See: https://travis-ci.org/azavea/docker-django/builds/352407238