### PR TITLE
Bump Django to version 2.0.6

### DIFF
--- a/2.0/requirements.txt
+++ b/2.0/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.7.1
-django==2.0.5
+django==2.0.6
 psycopg2==2.7.4 --no-binary psycopg2
 gevent==1.2.2


### PR DESCRIPTION
## Overview

Update Django 2.0.x.

See: https://docs.djangoproject.com/en/2.0/releases/2.0.6/

Fixes #51

## Testing

See Travis CI Build: https://travis-ci.org/azavea/docker-django/builds/387979325