### PR TITLE
Bump Django versions to 1.11.14 and 2.0.7

### DIFF
--- a/1.11/requirements.txt
+++ b/1.11/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.8.1
-django==1.11.13
+django==1.11.14
 psycopg2==2.7.4 --no-binary psycopg2
 gevent==1.3.2.post0

--- a/2.0/requirements.txt
+++ b/2.0/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.8.1
-django==2.0.6
+django==2.0.7
 psycopg2==2.7.4 --no-binary psycopg2
 gevent==1.3.2.post0

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ An example of how to use `cibuild` to build and test an image:
 
 ```bash
 $ CI=1 VERSION=2.0 PYTHON_VERSION=3.6 \
-  PG_MAJOR=10 PG_VERSION=10.4-2.pgdg90+1 VARIANT=slim
+  PG_MAJOR=10 PG_VERSION=10.4-2.pgdg90+1 VARIANT=slim \
   ./scripts/cibuild
 ```


### PR DESCRIPTION
## Overview

Update Django 1.11.x and 2.0.x.

See:

 * https://docs.djangoproject.com/en/2.0/releases/2.0.7/
 * https://docs.djangoproject.com/en/2.0/releases/1.11.14/

Fixes #54 

## Testing

See Travis CI build: https://travis-ci.org/azavea/docker-django/builds/399245448