### PR TITLE
Fallback to IPv4 pool to fix keyserver receive failed

### DIFF
--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -18,7 +18,8 @@ RUN set -ex; \
 # uid                  PostgreSQL Debian Repository
 	key='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8'; \
 	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	(gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" \
+	    || gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys "$key"); \
 	gpg --export "$key" > /etc/apt/trusted.gpg.d/postgres.gpg; \
 	rm -rf "$GNUPGHOME"; \
 	apt-key list


### PR DESCRIPTION
## Overview

Travis CI builds were failing, seemingly at random. After further investigation, it turned out this was happening because IPv6 networking for Docker is disabled by [default](https://docs.docker.com/v17.09/engine/userguide/networking/default_network/ipv6/), and the SKS Keyservers high-availability pool contains some IPv6-only servers:

* https://github.com/nodejs/docker-node/issues/380#issuecomment-306451705
* https://github.com/travis-ci/travis-ci/issues/8711 (closed due to inactivity)
* https://sks-keyservers.net/status/

This PR adds a conditional expression to fallback to the IPv4-only SKS pool if we get an IPv6 server from the high-availability pool.

Fixes #56 

## Testing

See Travis CI build: https://travis-ci.org/azavea/docker-django/jobs/400941173

```bash
---> Running in 01cb1a99d43e
+ key=B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+ mktemp -d
+ export GNUPGHOME=/tmp/tmp.FErDewuJ8q
+ gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
gpg: keybox '/tmp/tmp.FErDewuJ8q/pubring.kbx' created
gpg: keyserver receive failed: Cannot assign requested address
+ gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
gpg: /tmp/tmp.FErDewuJ8q/trustdb.gpg: trustdb created
gpg: key 7FCC7D46ACCC4CF8: public key "PostgreSQL Debian Repository" imported
gpg: no ultimately trusted keys found
gpg: Total number processed: 1
gpg:               imported: 1
```