### PR TITLE
Use pgp-happy-eyeballs to fix pgp keyserver DNS resolution errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ env:
   - VERSION=2.0 PYTHON_VERSION=3.7 PG_MAJOR=10 PG_VERSION=10.5-1.pgdg90+1 VARIANT=slim
   - VERSION=2.0 PYTHON_VERSION=3.7 PG_MAJOR=10 PG_VERSION=10.5-r0 VARIANT=alpine
 
+before_script:
+  - wget -qO- 'https://github.com/tianon/pgp-happy-eyeballs/raw/master/hack-my-builds.sh' | bash
+
 script:
   - ./scripts/cibuild
 


### PR DESCRIPTION
# Overview
This PR configures travis builds to run `hack-my-build.sh`, which forces the Docker daemon to use `pgp-happy-eyeballs` to improve DNS lookups for PGP keyservers. This should help reduce the number of builds that fail due to DNS lookups.

# Testing
It's difficult to test this PR since the failures are intermittent. That said, I ran https://travis-ci.org/azavea/docker-django/builds/440767990 a few times and had no failures. 


Fixes #56 