### PR TITLE
Install the latest version of OpenSSL on Stretch builds

### DIFF
--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -36,6 +36,7 @@ RUN set -ex \
        libpq-dev \
     " \
     && deps=" \
+       openssl \
        gdal-bin \
        gettext \
        postgresql-client-$PG_MAJOR=$PG_VERSION \


### PR DESCRIPTION
# Overview

Make sure that the version of OpenSSL installed in the Stretch images is up to date. This ensures that we get the patched version `1.1.0j` that came in late November 2018 and that resolves security bugs listed [on the Quay Stretch images](https://quay.io/repository/azavea/django/manifest/sha256:b811c95bce1d38885ca10209e6a4796e3098b031555084ca175f806d126bf1d4?tab=vulnerabilities&fixable=true).

This shouldn't cause any dependency problems since it's a patch. Additionally, @jwalgran noted that the dependency tree shows OpenSSL is only required as a dependency to `ca-certificates`, and has a wide version range: https://github.com/azavea/american-water-tank-management/issues/84#issuecomment-444215952

Connects https://github.com/azavea/american-water-tank-management/issues/84

## Testing instructions

1. Verify that Travis builds succeed
2. Run `export CI=1 VERSION=1.9 PYTHON_VERSION=2.7 PG_MAJOR=9.4 PG_VERSION=9.4.20-1.pgdg90+1 VARIANT=slim`
3. Run `./scripts/cibuild`
4. Get the ID of the freshly-built container and run `docker run -it --entrypoint openssl <image_id> version` and confirm that OpenSSL `1.1.0j1` is installed 