### PR TITLE
Bump Django to version 1.11.7

### DIFF
--- a/1.11/requirements.txt
+++ b/1.11/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.9.0
-django==1.11.16
+django==1.11.17
 psycopg2==2.7.6.1 --no-binary psycopg2
 gevent==1.3.7


### PR DESCRIPTION
## Overview

Update Django 1.11.x.

See:

* https://docs.djangoproject.com/en/2.1/releases/1.11.17/

Fixes #67 

## Testing

See the Travis CI build: https://travis-ci.org/azavea/docker-django/builds/466070595