### PR TITLE
Bump Django versions to 2.0.10 and 1.11.18

### DIFF
--- a/1.10/requirements.txt
+++ b/1.10/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.9.0
 django==1.10.8
 psycopg2==2.7.6.1 --no-binary psycopg2
-gevent==1.3.7
+gevent==1.4.0

--- a/1.11/requirements.txt
+++ b/1.11/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.9.0
-django==1.11.17
+django==1.11.18
 psycopg2==2.7.6.1 --no-binary psycopg2
 gevent==1.3.7

--- a/1.11/requirements.txt
+++ b/1.11/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.9.0
 django==1.11.18
 psycopg2==2.7.6.1 --no-binary psycopg2
-gevent==1.3.7
+gevent==1.4.0

--- a/1.9/requirements.txt
+++ b/1.9/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.9.0
 django==1.9.13
 psycopg2==2.7.6.1 --no-binary psycopg2
-gevent==1.3.7
+gevent==1.4.0

--- a/2.0/requirements.txt
+++ b/2.0/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.9.0
-django==2.0.9
+django==2.0.10
 psycopg2==2.7.6.1 --no-binary psycopg2
 gevent==1.3.7

--- a/2.0/requirements.txt
+++ b/2.0/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.9.0
 django==2.0.10
 psycopg2==2.7.6.1 --no-binary psycopg2
-gevent==1.3.7
+gevent==1.4.0


### PR DESCRIPTION
## Overview

Update Django 2.0.x and 1.11.x.

See:

* https://docs.djangoproject.com/en/2.0/releases/2.0.10/
* https://docs.djangoproject.com/en/2.0/releases/1.11.18/

Closes #70.

## Testing instructions

See Travis CI build: https://travis-ci.org/azavea/docker-django/builds/478423029