### PR TITLE
Upgrade Django 1.11.23 and 2.2.4

### DIFF
--- a/1.11/requirements.txt
+++ b/1.11/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.9.0
-django==1.11.22
+django==1.11.23
 psycopg2==2.8.3
 gevent==1.4.0

--- a/2.2/requirements.txt
+++ b/2.2/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.9.0
-django==2.2.3
+django==2.2.4
 psycopg2==2.8.3
 gevent==1.4.0


### PR DESCRIPTION
Upgrades Django 1.11.x and 2.2.x to the most recent patch release.

See: https://www.djangoproject.com/weblog/2019/aug/01/security-releases/

Fix #82 

---

**Testing**

See: https://travis-ci.org/azavea/docker-django/builds/567833166