### PR TITLE
Bump to Django 2.2.6 and 1.11.25

### DIFF
--- a/1.11/requirements.txt
+++ b/1.11/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.9.0
-django==1.11.24
+django==1.11.25
 psycopg2==2.8.3
 gevent==1.4.0

--- a/2.2/requirements.txt
+++ b/2.2/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.9.0
-django==2.2.5
+django==2.2.6
 psycopg2==2.8.3
 gevent==1.4.0


### PR DESCRIPTION
Bump Django to accommodate security release.

See: https://www.djangoproject.com/weblog/2019/oct/01/bugfix-releases/

Resolves #88 

---

**Testing**

See Travis CI build: https://travis-ci.org/azavea/docker-django/builds/592010569