### PR TITLE
Upgrade to Django 2.2.7 and 1.11.27

### DIFF
--- a/1.11/requirements.txt
+++ b/1.11/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.9.0
-django==1.11.25
+django==1.11.26
 psycopg2==2.8.3
 gevent==1.4.0

--- a/2.2/requirements.txt
+++ b/2.2/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.9.0
-django==2.2.6
+django==2.2.7
 psycopg2==2.8.3
 gevent==1.4.0


### PR DESCRIPTION
## Overview

These updates contain several bugfixes for Django. See release notes for [2.2.7](https://docs.djangoproject.com/en/2.2/releases/2.2.7/) and [1.11.26](https://docs.djangoproject.com/en/2.2/releases/1.11.26/).

Resolves #90.

## Testing Instructions

* Confirm that [Travis build](https://travis-ci.org/azavea/docker-django/builds/607840189) passes.