### PR TITLE
Upgrade Django to 2.2.10 and 1.11.28

### DIFF
--- a/1.11/requirements.txt
+++ b/1.11/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==20.0.4
-django==1.11.27
+django==1.11.28
 psycopg2==2.8.4
 gevent==1.4.0

--- a/2.2/requirements.txt
+++ b/2.2/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==20.0.4
-django==2.2.9
+django==2.2.10
 psycopg2==2.8.4
 gevent==1.4.0


### PR DESCRIPTION
Upgrades Django to 2.2.10 and 1.11.28 to apply a high severity security patch.

See: https://www.djangoproject.com/weblog/2020/feb/03/security-releases/

Resolves #99 

---

**Testing**

See Travis CI build: https://travis-ci.org/azavea/docker-django/builds/645528801