### PR TITLE
Bump to Django 2.2.12

### DIFF
--- a/1.11/requirements.txt
+++ b/1.11/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==20.0.4
 django==1.11.29
-psycopg2==2.8.4
+psycopg2==2.8.5
 gevent==1.4.0

--- a/2.2/requirements.txt
+++ b/2.2/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==20.0.4
-django==2.2.11
-psycopg2==2.8.4
+django==2.2.12
+psycopg2==2.8.5
 gevent==1.4.0


### PR DESCRIPTION
Bump Django to accommodate security release.

See: https://www.djangoproject.com/weblog/2020/apr/01/bugfix-releases/

Resolves #105 

---

**Testing**

See Travis CI build: https://travis-ci.org/github/azavea/docker-django/builds/671773526