### PR TITLE
Automatically mark inactive issues / PRs as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: "Mark stale issues and pull requests"
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: >
+            This issue has been automatically marked as stale because it has
+            not had recent activity. It will be closed if no further activity
+            occurs.
+        stale-pr-message: >
+            This pull request has been automatically marked as stale because
+            it has not had recent activity. It will be closed if no further
+            activity occurs.
+        days-before-stale: 60
+        days-before-close: 7
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'


### PR DESCRIPTION
This sets up a workflow with a [GitHub Action](https://github.com/actions/stale) to mark inactive issues as stale after 60 days, closing them after being marked stale for 7 days.

[`schedule` triggers](https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule) are only run on the default branch for the repository. I created a test issue in a separate repository to test this workflow: https://github.com/ColeKettler/stale-action-test/issues/1

The workflow in the test repo is identical to the workflow in this PR except that it's set to immediately mark actions as stale and close them and it runs once every minute. You should see that the issue was marked as stale and then closed.

Resolves #101 