### PR TITLE
Bump to Django 2.2.14

### DIFF
--- a/2.2/requirements.txt
+++ b/2.2/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==20.0.4
-django==2.2.13
+django==2.2.14
 psycopg2==2.8.5
 gevent==1.4.0


### PR DESCRIPTION
Upgrade Django to the most recent patch release.

See: https://www.djangoproject.com/weblog/2020/jul/01/django-bugfix-releases-308-2214/

---

**Testing**

See: https://github.com/azavea/docker-django/actions/runs/158469748

Fixes https://github.com/azavea/docker-django/issues/115