### PR TITLE
Connect Actions badge to default branch status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-django
 
-![](https://github.com/azavea/docker-django/workflows/CI/badge.svg)
+[![CI](https://github.com/azavea/docker-django/workflows/CI/badge.svg?branch=master)](https://github.com/azavea/docker-django/actions?query=workflow%3ACI)
 
 This repository contains a collection of templated `Dockerfile` for image variants designed to support Django through the Gunicorn WSGI HTTP server. In addition, these images include support for GeoDjango, PostgreSQL, and Gevent.
 


### PR DESCRIPTION
Ensures that the badge will only reflect the build status for the default branch. I've also turned the badge into a link to the workflow page.