### PR TITLE
Bump to Django 2.2.16 and add support for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/2.2"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "azavea/operations"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "azavea/operations"

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -21,8 +21,8 @@ jobs:
             pg_major: 12
             pg_version: 12.2-r0
           - variant: slim
-            pg_major: 10
-            pg_version: 10.13-1.pgdg100+1
+            pg_major: 11
+            pg_version: 11.9-1.pgdg100+1
     env:
       DOCKER_BUILDKIT: 1
       VERSION: ${{ matrix.django_version }}

--- a/2.2/requirements.txt
+++ b/2.2/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==20.0.4
-django==2.2.15
+django==2.2.16
 psycopg2==2.8.5
 gevent==1.4.0


### PR DESCRIPTION
Upgrade Django to the most recent patch release.

See: https://www.djangoproject.com/weblog/2020/sep/01/security-releases/

---

**Testing**

See: https://github.com/azavea/docker-django/actions/runs/235087419

Fixes https://github.com/azavea/docker-django/issues/120