### PR TITLE
Bump to Django 2.2.17 and add support for Python 3.9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/2.2"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     reviewers:
       - "azavea/operations"
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         django_version: ["2.2"]
-        python_version: ["3.6", "3.7", "3.8"]
+        python_version: ["3.6", "3.7", "3.8", "3.9"]
         variant: [alpine, slim]
         include:
           - variant: alpine

--- a/2.2/requirements.txt
+++ b/2.2/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==20.0.4
-django==2.2.16
+django==2.2.17
 psycopg2==2.8.6
 gevent==20.9.0


### PR DESCRIPTION
Upgrade Django to the most recent patch release.

See: https://docs.djangoproject.com/en/3.1/releases/2.2.17/

---

**Testing**

See: https://github.com/azavea/docker-django/actions/runs/345617962

Fixes #130 