### PR TITLE
Add support for Django 3.2

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        django_version: ["2.2"]
+        django_version: ["2.2", "3.2"]
         python_version: ["3.6", "3.7", "3.8", "3.9"]
         variant: [alpine, slim]
         include:

--- a/3.2/requirements.txt
+++ b/3.2/requirements.txt
@@ -1,0 +1,4 @@
+gunicorn==20.1.0
+django==3.2.2
+psycopg2==2.8.6
+gevent==21.1.2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository contains a collection of templated `Dockerfile` for image varian
 An example of how to use `cibuild` to build and test an image:
 
 ```bash
-$ CI=1 VERSION=2.2 PYTHON_VERSION=3.8 \
-  PG_MAJOR=10 PG_VERSION=10.11-1.pgdg100+1 VARIANT=slim \
+$ CI=1 VERSION=3.2 PYTHON_VERSION=3.9 \
+  PG_MAJOR=11 PG_VERSION=11.11-1.pgdg100+1 VARIANT=slim \
   ./scripts/cibuild
 ```

--- a/scripts/test
+++ b/scripts/test
@@ -9,7 +9,7 @@ fi
 
 function usage() {
     echo -n \
-"Usage: $(basename "$0")
+        "Usage: $(basename "$0")
 Test container images built from templates.
 "
 }
@@ -18,8 +18,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        docker \
-            run --rm "quay.io/azavea/django:$VERSION-python$PYTHON_VERSION-$VARIANT" --version
+        docker run --rm --entrypoint django-admin \
+            "quay.io/azavea/django:${VERSION}-python${PYTHON_VERSION}-${VARIANT}" --version
+
+        docker run --rm \
+            "quay.io/azavea/django:${VERSION}-python${PYTHON_VERSION}-${VARIANT}" --version
     fi
 fi
-


### PR DESCRIPTION
Add support for the next LTS release of Django.

See: https://docs.djangoproject.com/en/3.2/releases/3.2/

---

**Testing**

```console
[maiden:docker-django]$ docker run --rm --entrypoint bash \
    -it -p8000:8000 quay.io/azavea/django:3.2-python3.9-slim
root@1cf6ba74af9e:/# django-admin startproject hello_world
root@1cf6ba74af9e:/# python hello_world/manage.py migrate
Operations to perform:
  Apply all migrations: admin, auth, contenttypes, sessions
Running migrations:
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying admin.0001_initial... OK
  Applying admin.0002_logentry_remove_auto_add... OK
  Applying admin.0003_logentry_add_action_flag_choices... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying auth.0007_alter_validators_add_error_messages... OK
  Applying auth.0008_alter_user_username_max_length... OK
  Applying auth.0009_alter_user_last_name_max_length... OK
  Applying auth.0010_alter_group_name_max_length... OK
  Applying auth.0011_update_proxy_permissions... OK
  Applying auth.0012_alter_user_first_name_max_length... OK
  Applying sessions.0001_initial... OK
root@1cf6ba74af9e:/# python hello_world/manage.py runserver 0.0.0.0:8000
Watching for file changes with StatReloader
Performing system checks...

System check identified no issues (0 silenced).
May 11, 2021 - 18:07:57
Django version 3.2.2, using settings 'hello_world.settings'
Starting development server at http://0.0.0.0:8000/
Quit the server with CONTROL-C.
```

In another window, verify the development server is accessible.

```console
[maiden:~]$ xh localhost:8000 --headers
HTTP/1.1 200 OK
content-length: 10697
content-type: text/html
date: Tue, 11 May 2021 18:08:06 GMT
referrer-policy: same-origin
server: WSGIServer/0.2 CPython/3.9.5
x-content-type-options: nosniff
x-frame-options: DENY
```

Also, see that all checks are passing below.

Resolves #149 