### PR TITLE
Downgrade to psycopg2 2.8.6 on Django 2.2

### DIFF
--- a/2.2/requirements.txt
+++ b/2.2/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==20.1.0
 django==2.2.24
-psycopg2==2.9.1
+psycopg2==2.8.6
 gevent==21.1.2


### PR DESCRIPTION
The upgrade to Psycopg 2 `2.9.1` is causing variations of the following error in Django 2.2:

```python
AssertionError: database connection isn't set to UTC
```

The Django team [has established](https://github.com/psycopg/psycopg2/issues/1293#issuecomment-866709996) they are not going to backport the fix into Django 2.2, per some LTS policy.

Connects https://github.com/azavea/mub-monitor/issues/819

See: 
- https://github.com/psycopg/psycopg2/issues/1293#issuecomment-862835147
- https://github.com/django/django/pull/14530




